### PR TITLE
[GITHUB-2] Fixes APT install for Bionic

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,7 @@ sansible_newrelic_integration_infra_apt_key: 8ECCE87C
 sansible_newrelic_integration_infra_apt_repo: "deb [arch=amd64]
   https://download.newrelic.com/infrastructure_agent/linux/apt
   {{ ansible_distribution_release }}   main"
+sansible_newrelic_integration_infra_apt_repo_keyserver: keyserver.ubuntu.com
 sansible_newrelic_integration_infra_group: newrelic
 sansible_newrelic_integration_infra_settings: {}
 sansible_newrelic_integration_infra_start_on_boot: no

--- a/tasks/build.yml
+++ b/tasks/build.yml
@@ -12,15 +12,22 @@
     - apt-transport-https
     - apt-utils
 
-- name: Ensure New Relic PGP key is known to the server
+- name: Download New Relic Infra PGP key (works with Bionic behind a proxy)
   become: yes
-  apt_key:
-    id: "{{ sansible_newrelic_integration_infra_apt_key }}"
-    keyserver: hkp://keyserver.ubuntu.com:80
-    state: present
+  get_url:
+    dest: /usr/local/src/newrelic_infra.asc
+    mode: 0644
+    url: "https://{{ sansible_newrelic_integration_infra_apt_repo_keyserver }}/pks/lookup?op=get&search=0x{{ sansible_newrelic_integration_infra_apt_key }}"
   retries: 2
   register: apt_result
   until: apt_result is succeeded
+
+- name: Ensures New Relic Infra PGP key is known
+  become: yes
+  apt_key:
+    file: /usr/local/src/newrelic_infra.asc
+    id: "{{ sansible_newrelic_integration_infra_apt_key }}"
+    state: present
 
 - name: Add New Relic APT repository
   become: yes


### PR DESCRIPTION
Switches to downloading key directly to get around proxy issues
with apt key when running on Bionic.